### PR TITLE
Create/mount all native views after app.start

### DIFF
--- a/platform/nativescript/runtime/index.js
+++ b/platform/nativescript/runtime/index.js
@@ -39,15 +39,18 @@ Vue.prototype.$start = function () {
 }
 
 const mount = function (el, hydrating) {
-    mountComponent(this, el, hydrating)
-
     if (this.__is_root__) {
-        let view = this.$el.nativeView
+        const self = this
         start({
             create() {
-                return view
+                // Call mountComponent in the create callback when the IOS app loop has started
+                // https://github.com/rigor789/nativescript-vue/issues/24
+                mountComponent(self, el, hydrating)
+                return self.$el.nativeView;
             }
         })
+    } else {
+        mountComponent(this, el, hydrating)
     }
 }
 


### PR DESCRIPTION
Resolves #24

The `UIGestureGraphEdge Assertion failure ...` seems pretty mystical to me, but I think it was due to the fact that the native ios views in the app-component are created **before** `application.start()`.

Moving `mountComponent()`(where the elements are created) inside the `create()` callback of the `application.start()`  seems to resolve the issue.