### PR TITLE
Example how you can use NativeScript UI plugins in Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,29 @@ This project is in its very early stages, so please don't try to use it for any 
  If you feel like contributing to this project, that’s awesome! Start by reading [this repo’s `CONTRIBUTING.MD`](https://github.com/rigor789/nativescript-vue/blob/master/CONTRIBUTING.md) file for details on the required development setup, how to send pull requests, and how to run this repo’s sample app.
 
 If you’d like to get involved with making Vue integration for NativeScript happen, join us in the #vue channel on the [NativeScript community Slack](http://tinyurl.com/nativescriptSlack). 
+
+## Using other plugins
+Plugins work as in any other NativeScript app, but you may wonder how UI plugin would work with Vue.
+
+UI plugins work almost identical to how you'd use a NativeScript UI plugin in an Angular app. For instance consider this example usage of [nativescript-gradient](https://github.com/EddyVerbruggen/nativescript-gradient) which is used in the [listview sample](samples/app/app-with-list-view.js):
+
+Install the plugin by running this command in the samples folder:
+
+```sh
+tns plugin add nativescript-gradient
+```
+
+Open your vue file and right after the imports at the top, do:
+
+```js
+Vue.registerElement("gradient", () => require("nativescript-gradient").Gradient);
+```
+
+Then in your view template, add this to recreated the gradient in the sample:
+
+```xml
+<gradient direction="to right" colors="#FF0077, red, #FF00FF" class="p-15">
+  <label class="p-5 c-white" horizontalAlignment="center" text="My gradients are the best." textWrap="true"></label>
+  <Label class="p-5 c-white" horizontalAlignment="center" text="It's true." textWrap="true"></Label>
+</gradient>
+```

--- a/samples/app/app-with-list-view.js
+++ b/samples/app/app-with-list-view.js
@@ -8,7 +8,7 @@ const Label = require('ui/label').Label
 const Button = require('ui/button').Button
 
 Vue.prototype.$http = http
-Vue.registerElement("gradient", () => require("nativescript-gradient").Gradient);
+Vue.registerElement('gradient', () => require('nativescript-gradient').Gradient);
 
 new Vue({
     data: {

--- a/samples/app/app-with-list-view.js
+++ b/samples/app/app-with-list-view.js
@@ -8,6 +8,7 @@ const Label = require('ui/label').Label
 const Button = require('ui/button').Button
 
 Vue.prototype.$http = http
+Vue.registerElement("gradient", () => require("nativescript-gradient").Gradient);
 
 new Vue({
     data: {
@@ -26,7 +27,13 @@ new Vue({
                 <action-item text="change" android.position="popup" ios.position="right" @tap="chooseSubreddit"></action-item>
             </action-bar>
             <stack-layout>
-                <list-view :items="items" class="list-group" :templateSelector="templateSelector" separatorColor="red" @itemTap="onItemTap" @loaded="onLoaded" @loadMoreItems="onLoadMoreItems">
+
+                <gradient direction="to right" colors="#FF0077, red, #FF00FF" class="p-15">
+                  <label class="p-5 c-white" horizontalAlignment="center" text="My gradients are the best." textWrap="true"></label>
+                  <Label class="p-5 c-white" horizontalAlignment="center" text="It's true." textWrap="true"></Label>
+                </gradient>
+
+                  <list-view :items="items" class="list-group" :templateSelector="templateSelector" separatorColor="red" @itemTap="onItemTap" @loaded="onLoaded" @loadMoreItems="onLoadMoreItems">
                     <template scope="item">
                         <stack-layout orientation="horizontal" class="list-group-item">
                             <image :src="item.image" class="thumb"></image>

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,6 +13,7 @@
     }
   },
   "dependencies": {
+    "nativescript-gradient": "^2.0.0",
     "nativescript-theme-core": "~1.0.2",
     "nativescript-vue": "^0.1.3",
     "tns-core-modules": "^3.0.0",


### PR DESCRIPTION
This PR adds an example to the repo on how to use NativeScript UI plugin in your Vue app. It shows how to add a gradient like this:

![simulator screen shot 12 aug 2017 14 41 09](https://user-images.githubusercontent.com/1426370/29240793-7d3a7c24-7f6c-11e7-82d9-ff7d98282500.png)
