### PR TITLE
improuve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,3 @@ This project is in its very early stages, so please don't try to use it for any 
  If you feel like contributing to this project, that’s awesome! Start by reading [this repo’s `CONTRIBUTING.MD`](https://github.com/rigor789/nativescript-vue/blob/master/CONTRIBUTING.md) file for details on the required development setup, how to send pull requests, and how to run this repo’s sample app.
 
 If you’d like to get involved with making Vue integration for NativeScript happen, join us in the #vue channel on the [NativeScript community Slack](http://tinyurl.com/nativescriptSlack). 
-
-## Using other plugins
-Plugins work as in any other NativeScript app, but you may wonder how UI plugin would work with Vue.
-
-UI plugins work almost identical to how you'd use a NativeScript UI plugin in an Angular app. For instance consider this example usage of [nativescript-gradient](https://github.com/EddyVerbruggen/nativescript-gradient) which is used in the [listview sample](samples/app/app-with-list-view.js):
-
-Install the plugin by running this command in the samples folder:
-
-```sh
-tns plugin add nativescript-gradient
-```
-
-Open your vue file and right after the imports at the top, do:
-
-```js
-Vue.registerElement("gradient", () => require("nativescript-gradient").Gradient);
-```
-
-Then in your view template, add this to recreated the gradient in the sample:
-
-```xml
-<gradient direction="to right" colors="#FF0077, red, #FF00FF" class="p-15">
-  <label class="p-5 c-white" horizontalAlignment="center" text="My gradients are the best." textWrap="true"></label>
-  <Label class="p-5 c-white" horizontalAlignment="center" text="It's true." textWrap="true"></Label>
-</gradient>
-```

--- a/docs/_toc.md
+++ b/docs/_toc.md
@@ -2,11 +2,16 @@
 - <span>Development</span>
     - [Installation - NativeScript](/installation-nativescript)
     - [Installation - Vue Plugin](/installation-nativescript-vue)
-    - [Quick Start](/installation)
+    - [Quick Start](/quick-start)
+    - [Using NativeScript Plugins](/using-nativescript-plugins)
+    - [Using Vue Modules](/using-vue-modules)
+    - [Templates](/templates)
+    - [Articles](/articles)
     - [Troubleshooting](/troubleshooting)
+    - [Contributing](/contributing)
 - <span>Elements</span>
     - <small>Layout</small>
-        - [AbsolueLayout](/elements/layout/absolute-layout)
+        - [AbsoluteLayout](/elements/layout/absolute-layout)
         - [DockLayout](/elements/layout/dock-layout)
         - [GridLayout](/elements/layout/grid-layout)
         - [StackLayout](/elements/layout/stack-layout)

--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,0 +1,9 @@
+---
+title: Articles
+---
+
+- [A new Vue for NativeScript](https://www.nativescript.org/blog/a-new-vue-for-nativescript)
+- [Vue.js and NativeScript in One Minute](https://www.nativescript.org/blog/vue-and-nativescript-in-one-minute)
+- [Building Native iOS and Android Apps With Vue and NativeScript](https://developer.telerik.com/products/nativescript/native-ios-android-vue-nativescript/)
+- [Native apps with Vue.js: Weex or NativeScript?
+](https://hackernoon.com/native-apps-with-vue-js-weex-or-nativescript-8d8f0bac041d)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,7 @@
+---
+title: Contributing
+---
+
+If you feel like contributing to this project, that’s awesome! Start by reading [this repo’s `CONTRIBUTING.MD`](https://github.com/rigor789/nativescript-vue/blob/master/CONTRIBUTING.md) file for details on the required development setup, how to send pull requests, and how to run this repo’s sample app.
+
+If you’d like to get involved with making Vue integration for NativeScript happen, join us in the #vue channel on the [NativeScript community Slack](http://tinyurl.com/nativescriptSlack). 

--- a/docs/elements/components/button.md
+++ b/docs/elements/components/button.md
@@ -1,0 +1,5 @@
+---
+title: Button
+---
+
+TODO

--- a/docs/elements/components/label.md
+++ b/docs/elements/components/label.md
@@ -1,0 +1,5 @@
+---
+title: Label
+---
+
+TODO

--- a/docs/elements/components/text-field.md
+++ b/docs/elements/components/text-field.md
@@ -1,0 +1,5 @@
+---
+title: TextField
+---
+
+TODO

--- a/docs/elements/layout/absolute-layout.md
+++ b/docs/elements/layout/absolute-layout.md
@@ -1,0 +1,5 @@
+---
+title: AbsoluteLayout
+---
+
+TODO

--- a/docs/elements/layout/dock-layout.md
+++ b/docs/elements/layout/dock-layout.md
@@ -1,0 +1,5 @@
+---
+title: DockLayout
+---
+
+TODO

--- a/docs/elements/layout/grid-layout.md
+++ b/docs/elements/layout/grid-layout.md
@@ -1,0 +1,5 @@
+---
+title: GridLayout
+---
+
+TODO

--- a/docs/elements/layout/stack-layout.md
+++ b/docs/elements/layout/stack-layout.md
@@ -1,0 +1,5 @@
+---
+title: StackLayout
+---
+
+TODO

--- a/docs/elements/layout/wrap-layout.md
+++ b/docs/elements/layout/wrap-layout.md
@@ -1,0 +1,5 @@
+---
+title: WrapLayout
+---
+
+TODO

--- a/docs/installation-nativescript-vue.md
+++ b/docs/installation-nativescript-vue.md
@@ -1,0 +1,9 @@
+---
+title: Installation
+---
+
+Install `nativescrpipt-vue` using `npm` by running the following command:
+
+```sh
+npm install --save nativescript-vue
+```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,70 @@
+---
+title: Quick Start
+---
+
+## Using `nativescript-vue-template`
+
+1) Create a NativeScript app using `nativescript-vue-template`
+
+```sh
+tns create MyApp --template nativescript-vue-template
+```
+
+2) Run the app on Android or iOS:
+
+```sh
+tns run android
+```
+
+or
+
+```sh
+tns run ios
+```
+
+## Using `tns` CLI
+
+1) Create a NativeScript app
+
+```sh
+tns create sample-app
+```
+
+2) Install `nativescript-vue`
+
+```sh
+npm install --save nativescript-vue
+```
+3) Change `app.js` content to:
+
+```javascript
+const Vue = require('nativescript-vue/dist/index');
+
+new Vue({
+
+  template: `
+    <page>
+      <stack-layout>
+        <label text="{{ message }}"></label>
+      </stack-layout>
+    </page>
+  `,
+
+  data() {
+    message: "Hello Vue!",
+  },
+
+}).$start();
+```
+
+4) Run the app on Android or iOS:
+
+```sh
+tns run android
+```
+
+or
+
+```sh
+tns run ios
+```

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,14 @@
+---
+title: Templates
+---
+
+Following NativeScript templates extends `nativescript-vue` with more features such as support for Vue.js Single File Component (`.vue`). Use by creating app by running
+
+```sh
+tns create sample-app --template TEMPLATE_URL
+```
+
+- https://github.com/tralves/nativescript-vue-template
+- https://github.com/tralves/nativescript-vue-webpack-template
+- https://github.com/rigor789/nativescript-vue-rollup-template
+- https://github.com/tralves/nativescript-vue-rollup-template

--- a/docs/using-nativescript-plugins.md
+++ b/docs/using-nativescript-plugins.md
@@ -1,0 +1,28 @@
+---
+title: Using NativeScript Plugins
+---
+
+Plugins work as in any other NativeScript app, but you may wonder how UI plugin would work with Vue.
+
+UI plugins work almost identical to how you'd use a NativeScript UI plugin in an Angular app. For instance consider this example usage of [nativescript-gradient](https://github.com/EddyVerbruggen/nativescript-gradient) which is used in the [listview sample](samples/app/app-with-list-view.js):
+
+Install the plugin by running this command in the samples folder:
+
+```sh
+tns plugin add nativescript-gradient
+```
+
+Open your vue file and right after the imports at the top, do:
+
+```js
+Vue.registerElement("gradient", () => require("nativescript-gradient").Gradient);
+```
+
+Then in your view template, add this to recreated the gradient in the sample:
+
+```xml
+<gradient direction="to right" colors="#FF0077, red, #FF00FF" class="p-15">
+  <label class="p-5 c-white" horizontalAlignment="center" text="My gradients are the best." textWrap="true"></label>
+  <Label class="p-5 c-white" horizontalAlignment="center" text="It's true." textWrap="true"></Label>
+</gradient>
+```

--- a/docs/using-vue-modules.md
+++ b/docs/using-vue-modules.md
@@ -1,0 +1,11 @@
+---
+title: Using NativeScript Plugins
+---
+
+## vue-router
+
+...
+
+## Vuex
+
+...


### PR DESCRIPTION
- worked on "Installation" and "Quick Start" pages
- moved NS plugins usage from readme to a standalone page
- added "Templates" and "Articles" pages
